### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ end
 ```
 
 ```bash
-sudo bpftrace -p $PID -e "usdt:julia:test { @[comm] = count(); }"
+sudo bpftrace -p $PID -e "usdt::julia:test { @[comm] = count(); }"
 Attaching 1 probe...
 ^C
 


### PR DESCRIPTION
This change enables the example to work on my machine.

I don't really understand `bpftrace` syntax well enough to know if this is peculiar to the version I'm running, but just in case:
```
ccabrera@ubuntu:~/uprobes$ bpftrace --version
bpftrace v0.9.4
```